### PR TITLE
add bitcoin anchor simulation feature

### DIFF
--- a/sim/contracts/btc-simulation.clar
+++ b/sim/contracts/btc-simulation.clar
@@ -1,0 +1,190 @@
+;; ClaritySim Feature #2: Bitcoin Anchor Simulation
+;; Mock Bitcoin blocks and cross-chain events for testing BTC-Stacks bridges
+
+(define-constant CONTRACT-OWNER tx-sender)
+(define-constant ERR-NOT-AUTHORIZED (err u401))
+(define-constant ERR-INVALID-INPUT (err u400))
+(define-constant ERR-ANCHOR-NOT-FOUND (err u402))
+
+;; Bitcoin anchor state
+(define-data-var simulated-btc-height uint u0)
+(define-data-var anchor-simulation-active bool false)
+
+;; Mock Bitcoin blocks
+(define-map btc-blocks
+  uint
+  {
+    block-hash: (buff 32),
+    timestamp: uint,
+    tx-count: uint,
+    anchor-event: bool
+  }
+)
+
+;; Mock burn proofs (for testing proof-of-burn)
+(define-map burn-proofs
+  (buff 32)
+  {
+    btc-amount: uint,
+    stacks-recipient: principal,
+    confirmed: bool,
+    btc-height-recorded: uint
+  }
+)
+
+;; Cross-chain event log
+(define-map anchor-events
+  uint
+  {
+    event-type: (string-ascii 32),
+    btc-height-at-event: uint,
+    stacks-height-at-event: uint,
+    data: (string-ascii 256),
+    processed: bool
+  }
+)
+
+;; Data variables
+(define-data-var next-anchor-event-id uint u1)
+(define-data-var confirmations-required uint u6)
+
+;; Read-only functions
+(define-read-only (get-simulated-btc-height)
+  (var-get simulated-btc-height)
+)
+
+(define-read-only (get-btc-block (btc-h uint))
+  (map-get? btc-blocks btc-h)
+)
+
+(define-read-only (get-burn-proof (tx-id (buff 32)))
+  (map-get? burn-proofs tx-id)
+)
+
+(define-read-only (get-anchor-event (event-id uint))
+  (map-get? anchor-events event-id)
+)
+
+(define-read-only (is-burn-confirmed (tx-id (buff 32)))
+  (match (map-get? burn-proofs tx-id)
+    proof
+    (and (get confirmed proof) 
+         (>= (- (var-get simulated-btc-height) (get btc-height-recorded proof)) (var-get confirmations-required)))
+    false)
+)
+
+;; Public functions
+
+;; Initialize Bitcoin anchor simulation
+(define-public (init-btc-anchor (starting-btc-h uint))
+  (begin
+    (asserts! (is-eq tx-sender CONTRACT-OWNER) ERR-NOT-AUTHORIZED)
+    
+    (var-set simulated-btc-height starting-btc-h)
+    (var-set anchor-simulation-active true)
+    (ok { status: "btc-anchor-initialized", btc-height: starting-btc-h })
+  )
+)
+
+;; Advance Bitcoin blockchain
+(define-public (advance-btc-blocks (blocks-to-advance uint))
+  (let ((current-btc-h (var-get simulated-btc-height)))
+    (asserts! (> blocks-to-advance u0) ERR-INVALID-INPUT)
+    (asserts! (var-get anchor-simulation-active) ERR-NOT-AUTHORIZED)
+    
+    (let ((new-btc-h (+ current-btc-h blocks-to-advance)))
+      (var-set simulated-btc-height new-btc-h)
+      
+      (ok {
+        previous-btc-height: current-btc-h,
+        new-btc-height: new-btc-h,
+        blocks-advanced: blocks-to-advance
+      })
+    )
+  )
+)
+
+;; Mock a burn proof on Bitcoin
+(define-public (mock-burn-proof (tx-id (buff 32)) (btc-amount uint) (recipient principal))
+  (let ((current-btc-h (var-get simulated-btc-height)))
+    (asserts! (> btc-amount u0) ERR-INVALID-INPUT)
+    (asserts! (var-get anchor-simulation-active) ERR-NOT-AUTHORIZED)
+    
+    (map-set burn-proofs
+      tx-id
+      {
+        btc-amount: btc-amount,
+        stacks-recipient: recipient,
+        confirmed: false,
+        btc-height-recorded: current-btc-h
+      })
+    
+    (ok { tx-id: tx-id, status: "burn-recorded" })
+  )
+)
+
+;; Confirm burn proof after sufficient blocks
+(define-public (confirm-burn-proof (tx-id (buff 32)))
+  (match (map-get? burn-proofs tx-id)
+    proof
+    (let ((blocks-passed (- (var-get simulated-btc-height) (get btc-height-recorded proof))))
+      (begin
+        (asserts! (>= blocks-passed (var-get confirmations-required)) ERR-INVALID-INPUT)
+        
+        (map-set burn-proofs
+          tx-id
+          (merge proof { confirmed: true }))
+        
+        (ok { tx-id: tx-id, status: "burn-confirmed", confirmations: blocks-passed })
+      ))
+    ERR-ANCHOR-NOT-FOUND)
+)
+
+;; Emit cross-chain anchor event
+(define-public (emit-anchor-event (event-type (string-ascii 32)) (data (string-ascii 256)))
+  (let ((event-id (var-get next-anchor-event-id)))
+    (asserts! (var-get anchor-simulation-active) ERR-NOT-AUTHORIZED)
+    
+    (map-set anchor-events event-id {
+      event-type: event-type,
+      btc-height-at-event: (var-get simulated-btc-height),
+      stacks-height-at-event: stacks-block-height,
+      data: data,
+      processed: false
+    })
+    
+    (var-set next-anchor-event-id (+ event-id u1))
+    (ok event-id)
+  )
+)
+
+;; Mark anchor event as processed
+(define-public (process-anchor-event (event-id uint))
+  (match (map-get? anchor-events event-id)
+    event
+    (begin
+      (map-set anchor-events event-id (merge event { processed: true }))
+      (ok true))
+    ERR-ANCHOR-NOT-FOUND)
+)
+
+;; Set required confirmations
+(define-public (set-confirmations-required (confirmations uint))
+  (begin
+    (asserts! (is-eq tx-sender CONTRACT-OWNER) ERR-NOT-AUTHORIZED)
+    (asserts! (and (> confirmations u0) (<= confirmations u100)) ERR-INVALID-INPUT)
+    
+    (var-set confirmations-required confirmations)
+    (ok confirmations)
+  )
+)
+
+;; Get anchor simulation status
+(define-read-only (get-anchor-status)
+  {
+    active: (var-get anchor-simulation-active),
+    btc-height: (var-get simulated-btc-height),
+    confirmations-required: (var-get confirmations-required),
+    next-event-id: (var-get next-anchor-event-id)
+  }
+)


### PR DESCRIPTION
Add Bitcoin anchor simulation to mock BTC blocks, burn proofs, and cross-chain events for testing bridge logic and proof-of-burn mechanisms without touching Bitcoin testnet.